### PR TITLE
Replace HTML helpers with tag helpers

### DIFF
--- a/server/ERNI.PhotoDatabase.Server/Views/Home/Index.cshtml
+++ b/server/ERNI.PhotoDatabase.Server/Views/Home/Index.cshtml
@@ -1,5 +1,4 @@
-﻿@addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
-@model IEnumerable<(string Tag,int Count)>
+﻿@model IEnumerable<(string Tag,int Count)>
 @{
     Layout= "_Layout";
 }
@@ -7,7 +6,7 @@
 <div class="row search-result">
     @foreach (var item in Model)
     {
-        @Html.ActionLink(item.Tag, "Search", "Home", new { query=item.Tag }, new { @class = "badge badge-primary"})
+        <a asp-controller="Home" asp-action="Search" asp-route-query="@item.Tag" class="badge badge-primary">@item.Tag</a>
     }
 </div>
 

--- a/server/ERNI.PhotoDatabase.Server/Views/Home/Search.cshtml
+++ b/server/ERNI.PhotoDatabase.Server/Views/Home/Search.cshtml
@@ -15,7 +15,7 @@
                     <p class="card-text tags">
                         @foreach(var tag in sr.Tags)
                         {
-                            @Html.ActionLink(tag, "Search", "Home", new { query=tag }, new { @class = "badge badge-primary"})
+                            <a asp-controller="Home" asp-action="Search" asp-route-query="@tag" class="badge badge-primary">@tag</a>
                         }
                     </p>
                 </div>

--- a/server/ERNI.PhotoDatabase.Server/Views/Home/Upload.cshtml
+++ b/server/ERNI.PhotoDatabase.Server/Views/Home/Upload.cshtml
@@ -3,8 +3,7 @@
     Layout = "_Layout";
 }
 
-@using (Html.BeginForm("upload", "image", null, FormMethod.Post, false, new { @class = "form-inline my-2 my-lg-0", enctype="multipart/form-data" }))
-{
-	<input class="form-control mr-sm-2" type="file" multiple="multiple" name="files" aria-label="Upload">
-	<button class="btn btn-outline-success my-2 my-sm-0" type="submit">Upload</button>
-}
+<form asp-controller="Image" asp-action="Upload" method="post" asp-antiforgery="false" class="form-inline my-2 my-lg-0" enctype="multipart/form-data" >
+    <input class="form-control mr-sm-2" type="file" name="files" aria-label="Upload" multiple/>
+    <button class="btn btn-outline-success my-2 my-sm-0" type="submit">Upload</button>
+</form>

--- a/server/ERNI.PhotoDatabase.Server/Views/Shared/_Layout.cshtml
+++ b/server/ERNI.PhotoDatabase.Server/Views/Shared/_Layout.cshtml
@@ -12,7 +12,7 @@
 </head>
 <body>
     <nav class="navbar navbar-expand-lg navbar-light bg-light">
-        <a class="navbar-brand" href="#">ERNI Photo app</a>
+        <a asp-controller="Home" asp-action="Index" class="navbar-brand">ERNI Photo app</a>
         <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
             <span class="navbar-toggler-icon"></span>
         </button>
@@ -20,21 +20,19 @@
         <div class="collapse navbar-collapse" id="navbarSupportedContent">
             <ul class="navbar-nav mr-auto">
                 <li class="nav-item">
-                    @Html.ActionLink("Upload", "Upload", "Home")
+                    <a asp-controller="Home" asp-action="Upload">Upload</a>
                 </li>
             </ul>
-            @using (Html.BeginForm("index", "home", null, FormMethod.Get, false, new { @class = "form-inline my-2 my-lg-0" }))
-            {
-                <input class="form-control mr-sm-2" type="text" name="query" placeholder="Search" aria-label="Search">
+            <form asp-controller="Home" asp-action="Search" method="get" asp-antiforgery="false" class="form-inline my-2 my-lg-0">
+                <input type="text" placeholder="Search" aria-label="Search" name="query" class="form-control mr-sm-2"/>
                 <button class="btn btn-outline-success my-2 my-sm-0" type="submit">Search</button>
-            }
+            </form>
         </div>
     </nav>
 
     <div class="container">
         @RenderBody()
     </div>
-
 
     <!-- Optional JavaScript -->
     <!-- jQuery first, then Popper.js, then Bootstrap JS -->

--- a/server/ERNI.PhotoDatabase.Server/Views/_ViewImports.cshtml
+++ b/server/ERNI.PhotoDatabase.Server/Views/_ViewImports.cshtml
@@ -1,0 +1,1 @@
+﻿@addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers


### PR DESCRIPTION
Migrated all HTML helpers to the newer version - tag helpers. Functionality is the same but the syntax is more HTML-y, while still keeping all the intellisense and everything.