### PR TITLE
Fix file naming issue in upload

### DIFF
--- a/server/ERNI.PhotoDatabase.Server/Controllers/ImageController.cs
+++ b/server/ERNI.PhotoDatabase.Server/Controllers/ImageController.cs
@@ -71,7 +71,7 @@ namespace ERNI.PhotoDatabase.Server.Controllers
                     openReadStream.Read(data, 0, data.Length);
                     _dataProvider.Images.Add(new Image
                     {
-                        File = formFile.Name,
+                        File = formFile.FileName,
                         Content = data,
                         Tags = new[] {"office"}
                     });


### PR DESCRIPTION
Replace Name with FileName because Name now seems to always be "files" (name of the input field in the upload form).